### PR TITLE
Feature/cicd

### DIFF
--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -1,0 +1,12 @@
+files:
+    "/sbin/appstart" :
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+            #!/usr/bin/env bash
+            JAR_PATH=/var/app/current/application.jar
+
+            # run app
+            killall java
+            java -Dfile.encoding=UTF-8 -jar $JAR_PATH

--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -9,4 +9,4 @@ files:
 
             # run app
             killall java
-            nohup java -Dfile.encoding=UTF-8 -jar $JAR_PATH
+            java -Dfile.encoding=UTF-8 -jar $JAR_PATH

--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -9,4 +9,4 @@ files:
 
             # run app
             killall java
-            java -Dfile.encoding=UTF-8 -jar $JAR_PATH
+            nohup java -Dfile.encoding=UTF-8 -jar $JAR_PATH

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
 
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build --exclude-task test
         shell: bash
 
       - name: Get current time

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: ci/cd-practice
 on:
   push:
     branches:
-      - feature/cicd
+      - develop
   workflow_dispatch:
     inputs:
       tags:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: ci/cd-practice
+
+on:
+  push:
+    branches:
+      - feature/cicd
+
+jobs:
+  build:
+    name: CD Pipeline
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.11
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+        shell: bash
+
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Generate deployment package
+        run: |
+          mkdir -p deploy
+          cp build/libs/*.jar deploy/application.jar
+          cp Procfile deploy/Procfile
+          cp -r .ebextensions deploy/.ebextensions
+          cp -r .platform deploy/.platform
+          cd deploy && zip -r deploy.zip .
+      - name: Deploy to EB
+        uses: einaregilsson/beanstalk-deploy@v14
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: mashup-spring-search
+          environment_name: Mashupspringsearch-env
+          version_label: github-action-${{steps.current-time.outputs.formattedTime}}
+          region: ap-northeast-2
+          deployment_package: deploy/deploy.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - feature/cicd
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Manual build'
 
 jobs:
   build:

--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -1,0 +1,56 @@
+user                    nginx;
+error_log               /var/log/nginx/error.log warn;
+pid                     /var/run/nginx.pid;
+worker_processes        auto;
+worker_rlimit_nofile    33282;
+
+events {
+    use epoll;
+    worker_connections  1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  include       conf.d/*.conf;
+
+  map $http_upgrade $connection_upgrade {
+      default     "upgrade";
+  }
+
+  upstream springboot {
+    server 127.0.0.1:8080;
+    keepalive 1024;
+  }
+
+  server {
+      listen        80 default_server;
+
+      location / {
+          proxy_pass          http://springboot;
+          proxy_http_version  1.1;
+          proxy_set_header    Connection          $connection_upgrade;
+          proxy_set_header    Upgrade             $http_upgrade;
+
+          proxy_set_header    Host                $host;
+          proxy_set_header    X-Real-IP           $remote_addr;
+          proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+      }
+
+      access_log    /var/log/nginx/access.log main;
+
+      client_header_timeout 60;
+      client_body_timeout   60;
+      keepalive_timeout     60;
+      gzip                  off;
+      gzip_comp_level       4;
+
+      # Include the Elastic Beanstalk generated locations
+      include conf.d/elasticbeanstalk/healthd.conf;
+  }
+}

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: appstart

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,3 +52,7 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
 	useJUnitPlatform()
 }
+
+tasks.getByName<Jar>("jar") {
+	enabled = false
+}

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -1,12 +1,21 @@
 package mashup.spring.elegant.search.config
 
 
-import org.apache.http.HttpHost
-import org.elasticsearch.client.RestClient
+import mashup.spring.elegant.search.util.getEnvironment
 import org.elasticsearch.client.RestHighLevelClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate
 
+import org.springframework.data.elasticsearch.client.RestClients
+
+import org.springframework.data.elasticsearch.client.ClientConfiguration
+
+
+
+
+@Configuration
 class ElasticSearchConfig (
     @Value("\${es.url}")
     private val hostName: String,
@@ -14,10 +23,21 @@ class ElasticSearchConfig (
     private val port: Int
 ){
     // Elastic Search 와 통신하기 위한 rest client
-    @Bean
-    fun restHighLevelClient() : RestHighLevelClient =
-        RestHighLevelClient(RestClient
-                                .builder(
-                                    HttpHost(hostName, port, "http")))
 
+    private val username: String = getEnvironment("ES_USERNAME")
+    private val password: String = getEnvironment("ES_PASSWORD")
+
+    @Bean
+    fun client(): RestHighLevelClient? {
+        val clientConfiguration: ClientConfiguration = ClientConfiguration.builder()
+            .connectedTo("$hostName:$port")
+            .withBasicAuth(username, password)
+            .build()
+        return RestClients.create(clientConfiguration).rest()
+    }
+
+    @Bean
+    fun elasticsearchTemplate(): ElasticsearchRestTemplate? {
+        return ElasticsearchRestTemplate(client())
+    }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -21,10 +21,10 @@ class ElasticSearchConfig (
     private val PORT: Int,
     @Value("\${es.scheme}")
     private val SCHEME: String,
-    @Value("\${es.username}")
-    private val USERNAME: String,
-    @Value("\${es.password}")
-    private val PASSWORD: String
+//    @Value("\${es.username}")
+//    private val USERNAME: String,
+//    @Value("\${es.password}")
+//    private val PASSWORD: String
 ) {
 //    private val USERNAME: String = getEnvironment("ES_USERNAME")
 //    private val PASSWORD: String = getEnvironment("ES_PASSWORD")
@@ -36,19 +36,17 @@ class ElasticSearchConfig (
 
     private fun getRestClientBuilder() =
         RestClient.builder(HttpHost(HOST, PORT, SCHEME))
-            .setHttpClientConfigCallback {
-                    httpClientBuilder -> httpClientBuilder
-                .setDefaultCredentialsProvider(getCredentialProvider())
-            }.apply {
-                println("USERNAME : " + USERNAME)
-            }
+//            .setHttpClientConfigCallback {
+//                    httpClientBuilder -> httpClientBuilder
+//                .setDefaultCredentialsProvider(getCredentialProvider())
+//            }
 
-    private fun getCredentialProvider(): BasicCredentialsProvider {
-        val credentialsProvider = BasicCredentialsProvider()
-        credentialsProvider.setCredentials(
-            AuthScope.ANY,
-            UsernamePasswordCredentials(USERNAME, PASSWORD)
-        )
-        return credentialsProvider
-    }
+//    private fun getCredentialProvider(): BasicCredentialsProvider {
+//        val credentialsProvider = BasicCredentialsProvider()
+//        credentialsProvider.setCredentials(
+//            AuthScope.ANY,
+//            UsernamePasswordCredentials(USERNAME, PASSWORD)
+//        )
+//        return credentialsProvider
+//    }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -26,8 +26,6 @@ class ElasticSearchConfig (
     @Value("\${es.password}")
     private val PASSWORD: String
 ) {
-//    private val USERNAME: String = getEnvironment("ES_USERNAME")
-//    private val PASSWORD: String = getEnvironment("ES_PASSWORD")
 
     @Bean
     fun elasticsearchTemplate() = ElasticsearchRestTemplate(restHighLevelClient())
@@ -39,7 +37,7 @@ class ElasticSearchConfig (
             .setHttpClientConfigCallback {
                     httpClientBuilder -> httpClientBuilder
                 .setDefaultCredentialsProvider(getCredentialProvider())
-            }.apply { println("USERNAME : " + USERNAME) }
+            }
 
     private fun getCredentialProvider(): BasicCredentialsProvider {
         val credentialsProvider = BasicCredentialsProvider()

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -2,17 +2,16 @@ package mashup.spring.elegant.search.config
 
 
 import mashup.spring.elegant.search.util.getEnvironment
+import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.impl.client.BasicCredentialsProvider
+import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestHighLevelClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate
-
-import org.springframework.data.elasticsearch.client.RestClients
-
-import org.springframework.data.elasticsearch.client.ClientConfiguration
-
-
 
 
 @Configuration
@@ -21,23 +20,28 @@ class ElasticSearchConfig (
     private val hostName: String,
     @Value("\${es.port}")
     private val port: Int
-){
-    // Elastic Search 와 통신하기 위한 rest client
-
+) {
     private val username: String = getEnvironment("ES_USERNAME")
     private val password: String = getEnvironment("ES_PASSWORD")
 
     @Bean
-    fun client(): RestHighLevelClient? {
-        val clientConfiguration: ClientConfiguration = ClientConfiguration.builder()
-            .connectedTo("$hostName:$port")
-            .withBasicAuth(username, password)
-            .build()
-        return RestClients.create(clientConfiguration).rest()
-    }
+    fun elasticsearchTemplate() = ElasticsearchRestTemplate(restHighLevelClient())
 
-    @Bean
-    fun elasticsearchTemplate(): ElasticsearchRestTemplate? {
-        return ElasticsearchRestTemplate(client())
+    private fun restHighLevelClient() = RestHighLevelClient(getRestClientBuilder())
+
+    private fun getRestClientBuilder() =
+        RestClient.builder(HttpHost(hostName, port, "https"))
+            .setHttpClientConfigCallback {
+                    httpClientBuilder -> httpClientBuilder
+                .setDefaultCredentialsProvider(getCredentialProvider())
+            }
+
+    private fun getCredentialProvider(): BasicCredentialsProvider {
+        val credentialsProvider = BasicCredentialsProvider()
+        credentialsProvider.setCredentials(
+            AuthScope.ANY,
+            UsernamePasswordCredentials(username, password)
+        )
+        return credentialsProvider
     }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -1,7 +1,6 @@
 package mashup.spring.elegant.search.config
 
 
-import mashup.spring.elegant.search.util.getEnvironment
 import org.apache.http.HttpHost
 import org.apache.http.auth.AuthScope
 import org.apache.http.auth.UsernamePasswordCredentials
@@ -40,6 +39,8 @@ class ElasticSearchConfig (
             .setHttpClientConfigCallback {
                     httpClientBuilder -> httpClientBuilder
                 .setDefaultCredentialsProvider(getCredentialProvider())
+            }.apply {
+                println("USERNAME : " + USERNAME)
             }
 
     private fun getCredentialProvider(): BasicCredentialsProvider {

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -21,10 +21,10 @@ class ElasticSearchConfig (
     private val PORT: Int,
     @Value("\${es.scheme}")
     private val SCHEME: String,
-//    @Value("\${es.username}")
-//    private val USERNAME: String,
-//    @Value("\${es.password}")
-//    private val PASSWORD: String
+    @Value("\${es.username}")
+    private val USERNAME: String,
+    @Value("\${es.password}")
+    private val PASSWORD: String
 ) {
 //    private val USERNAME: String = getEnvironment("ES_USERNAME")
 //    private val PASSWORD: String = getEnvironment("ES_PASSWORD")
@@ -36,17 +36,17 @@ class ElasticSearchConfig (
 
     private fun getRestClientBuilder() =
         RestClient.builder(HttpHost(HOST, PORT, SCHEME))
-//            .setHttpClientConfigCallback {
-//                    httpClientBuilder -> httpClientBuilder
-//                .setDefaultCredentialsProvider(getCredentialProvider())
-//            }
+            .setHttpClientConfigCallback {
+                    httpClientBuilder -> httpClientBuilder
+                .setDefaultCredentialsProvider(getCredentialProvider())
+            }.apply { println("USERNAME : " + USERNAME) }
 
-//    private fun getCredentialProvider(): BasicCredentialsProvider {
-//        val credentialsProvider = BasicCredentialsProvider()
-//        credentialsProvider.setCredentials(
-//            AuthScope.ANY,
-//            UsernamePasswordCredentials(USERNAME, PASSWORD)
-//        )
-//        return credentialsProvider
-//    }
+    private fun getCredentialProvider(): BasicCredentialsProvider {
+        val credentialsProvider = BasicCredentialsProvider()
+        credentialsProvider.setCredentials(
+            AuthScope.ANY,
+            UsernamePasswordCredentials(USERNAME, PASSWORD)
+        )
+        return credentialsProvider
+    }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -17,12 +17,14 @@ import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate
 @Configuration
 class ElasticSearchConfig (
     @Value("\${es.url}")
-    private val hostName: String,
+    private val HOST: String,
     @Value("\${es.port}")
-    private val port: Int
+    private val PORT: Int,
+    @Value("\${es.scheme}")
+    private val SCHEME: String
 ) {
-    private val username: String = getEnvironment("ES_USERNAME")
-    private val password: String = getEnvironment("ES_PASSWORD")
+    private val USERNAME: String = getEnvironment("ES_USERNAME")
+    private val PASSWORD: String = getEnvironment("ES_PASSWORD")
 
     @Bean
     fun elasticsearchTemplate() = ElasticsearchRestTemplate(restHighLevelClient())
@@ -30,7 +32,7 @@ class ElasticSearchConfig (
     private fun restHighLevelClient() = RestHighLevelClient(getRestClientBuilder())
 
     private fun getRestClientBuilder() =
-        RestClient.builder(HttpHost(hostName, port, "https"))
+        RestClient.builder(HttpHost(HOST, PORT, SCHEME))
             .setHttpClientConfigCallback {
                     httpClientBuilder -> httpClientBuilder
                 .setDefaultCredentialsProvider(getCredentialProvider())
@@ -40,7 +42,7 @@ class ElasticSearchConfig (
         val credentialsProvider = BasicCredentialsProvider()
         credentialsProvider.setCredentials(
             AuthScope.ANY,
-            UsernamePasswordCredentials(username, password)
+            UsernamePasswordCredentials(USERNAME, PASSWORD)
         )
         return credentialsProvider
     }

--- a/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/config/ElasticSearchConfig.kt
@@ -21,10 +21,14 @@ class ElasticSearchConfig (
     @Value("\${es.port}")
     private val PORT: Int,
     @Value("\${es.scheme}")
-    private val SCHEME: String
+    private val SCHEME: String,
+    @Value("\${es.username}")
+    private val USERNAME: String,
+    @Value("\${es.password}")
+    private val PASSWORD: String
 ) {
-    private val USERNAME: String = getEnvironment("ES_USERNAME")
-    private val PASSWORD: String = getEnvironment("ES_PASSWORD")
+//    private val USERNAME: String = getEnvironment("ES_USERNAME")
+//    private val PASSWORD: String = getEnvironment("ES_PASSWORD")
 
     @Bean
     fun elasticsearchTemplate() = ElasticsearchRestTemplate(restHighLevelClient())

--- a/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
@@ -1,16 +1,16 @@
 package mashup.spring.elegant.search.controller
 
-import org.springframework.beans.factory.annotation.Autowired
+import mashup.spring.elegant.search.domain.search.Shop
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.ResponseEntity
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.client.RestTemplate
 
 @RestController
 class HealthCheckController (
     @Value("\${server.echo}")
     private val echo : String,
+    private val elasticsearchTemplate : ElasticsearchRestTemplate
 ){
 
     @Value("\${es.url}")
@@ -20,9 +20,10 @@ class HealthCheckController (
     fun healthCheck() = echo
 
     @GetMapping("/es")
-    fun esHealth(): ResponseEntity<String> {
-        val restTemplate: RestTemplate = RestTemplate()
+    fun esHealth(): String {
 
-        return restTemplate.getForEntity(esUrl, String::class.javaObjectType)
+        elasticsearchTemplate.indexOps(Shop::class.javaObjectType).create()
+
+        return "success"
     }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
@@ -2,17 +2,15 @@ package mashup.spring.elegant.search.controller
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RequestMapping("/api/v1/health-check")
 @RestController
 class HealthCheckController (
     @Value("\${server.echo}")
     private val echo : String
 ){
-    @GetMapping
-    fun health() = echo
 
+    @GetMapping("")
+    fun healthCheck() = echo
 
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
@@ -1,16 +1,28 @@
 package mashup.spring.elegant.search.controller
 
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestTemplate
 
 @RestController
 class HealthCheckController (
     @Value("\${server.echo}")
-    private val echo : String
+    private val echo : String,
 ){
+
+    @Value("\${es.url}")
+    private val esUrl = "localhost"
 
     @GetMapping("")
     fun healthCheck() = echo
 
+    @GetMapping("/es")
+    fun esHealth(): ResponseEntity<String> {
+        val restTemplate: RestTemplate = RestTemplate()
+
+        return restTemplate.getForEntity(esUrl, String::class.javaObjectType)
+    }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/api/v1/health-check")
 @RestController
-class TestController (
+class HealthCheckController (
     @Value("\${server.echo}")
     private val echo : String
 ){

--- a/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/controller/HealthCheckController.kt
@@ -1,29 +1,14 @@
 package mashup.spring.elegant.search.controller
 
-import mashup.spring.elegant.search.domain.search.Shop
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class HealthCheckController (
     @Value("\${server.echo}")
-    private val echo : String,
-    private val elasticsearchTemplate : ElasticsearchRestTemplate
+    private val echo : String
 ){
-
-    @Value("\${es.url}")
-    private val esUrl = "localhost"
-
     @GetMapping("")
     fun healthCheck() = echo
-
-    @GetMapping("/es")
-    fun esHealth(): String {
-
-        elasticsearchTemplate.indexOps(Shop::class.javaObjectType).create()
-
-        return "success"
-    }
 }

--- a/src/main/kotlin/mashup/spring/elegant/search/util/EnvironmentProvider.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/util/EnvironmentProvider.kt
@@ -1,3 +1,0 @@
-package mashup.spring.elegant.search.util
-
-fun getEnvironment(env: String): String = System.getenv(env)

--- a/src/main/kotlin/mashup/spring/elegant/search/util/EnvironmentProvider.kt
+++ b/src/main/kotlin/mashup/spring/elegant/search/util/EnvironmentProvider.kt
@@ -1,0 +1,3 @@
+package mashup.spring.elegant.search.util
+
+fun getEnvironment(env: String): String = System.getenv(env)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,4 +40,6 @@ es:
   url: localhost
   port: 9200
   scheme: http
+  username: mashup
+  password: mashup
 ---

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,7 @@
 es:
   url: search-mashup-spring-search-5stojescxljz22frzubuuqpauu.ap-northeast-2.es.amazonaws.com
   port: 443
+  scheme: https
 
 # 유레카 클라이언트 아직 사용 X
 eureka:
@@ -38,4 +39,5 @@ spring:
 es:
   url: localhost
   port: 9200
+  scheme: http
 ---

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 es:
-  url: https://search-mashup-spring-search-5stojescxljz22frzubuuqpauu.ap-northeast-2.es.amazonaws.com
+  url: search-mashup-spring-search-5stojescxljz22frzubuuqpauu.ap-northeast-2.es.amazonaws.com
   port: 443
 
 # 유레카 클라이언트 아직 사용 X

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 es:
-  url: localhost
-  port: 9200
+  url: https://search-mashup-spring-search-5stojescxljz22frzubuuqpauu.ap-northeast-2.es.amazonaws.com
+  port: 443
 
 # 유레카 클라이언트 아직 사용 X
 eureka:
@@ -27,3 +27,15 @@ eureka:
 
 server:
   echo: 엄준식은 살아있다.
+
+---
+spring:
+  config:
+    activate:
+      on-profile:
+        - local
+
+es:
+  url: localhost
+  port: 9200
+---

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,6 +40,4 @@ es:
   url: localhost
   port: 9200
   scheme: http
-  username: mashup
-  password: mashup
 ---

--- a/src/test/kotlin/mashup/spring/elegant/search/SearchApplicationTests.kt
+++ b/src/test/kotlin/mashup/spring/elegant/search/SearchApplicationTests.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class SearchApplicationTests {
+class MashupSpringBootApplicationTest {
 
 	@Test
 	fun contextLoads() {


### PR DESCRIPTION
#7 깃헙 액션 + 엘라스틱 빈스톡 cicd 연동입니다.

빈스톡에 올라간 애플리케이션이 AWS ES에 접근 할 수 있도록 계정 정보를 설정 해줬는데 이건 회의때 설명 드릴게요. (ElasticsearchConfig 부분)
확실히 레포가 퍼블릭이니 제약이 조금 있네요... 볼트 서버를 써야 하나... 어렵습니다 ㅋㅋ..

헬스체크 API uri를 
"api/v1/health-check" 에서 
"" 로 바꿨는데 엘라스틱 빈스톡에서 롤링 배포를 할 때 헬스체크를 한 뒤 서버가 떠있는게 확인 되면 로드밸런서가 요청을 보내주는데 그 과정에서 헬스체크 하는 default uri가 ""여서 바꿨습니다. (따로 설정 해줄수 있긴 한데 일단 기본값으로 뒀어요)